### PR TITLE
Proper list concatenation

### DIFF
--- a/update_whitelist.py
+++ b/update_whitelist.py
@@ -79,7 +79,7 @@ def overwrite_middleware():
 
     if WHITELISTED_IPS != None:
         WHITELISTED_IPS = WHITELISTED_IPS.split(',')
-        DEFAULT_SOURCE_RANGE.append(WHITELISTED_IPS)
+        DEFAULT_SOURCE_RANGE += WHITELISTED_IPS
 
     if EXCLUDED_IPS != None:
         EXCLUDED_IPS = EXCLUDED_IPS.split(',')


### PR DESCRIPTION
This solves the issue where IPs from WHITELISTED_IPS would be added as a list inside a list: `['127.0.0.1/32', ['127.0.0.2/32']]` instead values only.